### PR TITLE
Abort on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ vaultrs-login = "0"
 url = "2"
 chrono = "0"
 num-traits = "0"
+
+[profile]
+panic = "abort"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ url = "2"
 chrono = "0"
 num-traits = "0"
 
-[profile]
+[profile.release]
 panic = "abort"
 


### PR DESCRIPTION
Fail fast. Die on thread panic and leave it to service management to start the service again. 
We had an incident where a thread panicked, possibly due to a race condition, but the process remained up in a hard to detect dysfunctional state.