### PR TITLE
Add sans individually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acme-lib"
 version = "0.8.1"
-source = "git+https://github.com/DBCDK/acme-lib?branch=add-sans-individually#f12e10dbe34898c97e837aa45169a6968ea9a0b4"
+source = "git+https://github.com/DBCDK/acme-lib?branch=add-sans-individually#38c6919badae73ccfba9778435f0b8f361214af1"
 dependencies = [
  "base64 0.12.3",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acme-lib"
 version = "0.8.1"
-source = "git+https://github.com/DBCDK/acme-lib?branch=v0.8.1-reqwest#84a3b8ccf58660d33984fe0e8ff04c9b46de9ad8"
+source = "git+https://github.com/DBCDK/acme-lib?branch=add-sans-individually#f12e10dbe34898c97e837aa45169a6968ea9a0b4
 dependencies = [
  "base64 0.12.3",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acme-lib"
 version = "0.8.1"
-source = "git+https://github.com/DBCDK/acme-lib?branch=add-sans-individually#f12e10dbe34898c97e837aa45169a6968ea9a0b4
+source = "git+https://github.com/DBCDK/acme-lib?branch=add-sans-individually#f12e10dbe34898c97e837aa45169a6968ea9a0b4"
 dependencies = [
  "base64 0.12.3",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1"
 openssl = "0"
 base64 = "0"
 time = "=0.1.45" # same version as acme-lib uses
-acme-lib = { git = 'https://github.com/DBCDK/acme-lib', branch = 'v0.8.1-reqwest' }
+acme-lib = { git = 'https://github.com/DBCDK/acme-lib', branch = 'add-sans-individually' }
 regex = "1"
 lazy_static = "1"
 walkdir = "2"


### PR DESCRIPTION
acme-lib used to add Subject Alternative Names in CSRs as a singe string, which now seems to make letsencrypt choke