### PR TITLE
Replace time with chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time",
  "tokio 1.29.1",
  "trust-dns-resolver",
  "url 2.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ serde_derive = "1"
 serde_json = "1"
 openssl = "0"
 base64 = "0"
-time = "=0.1.45" # same version as acme-lib uses
 acme-lib = { git = 'https://github.com/DBCDK/acme-lib', branch = 'add-sans-individually' }
 regex = "1"
 lazy_static = "1"

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,3 @@
-extern crate time;
 extern crate walkdir;
 
 

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -25,6 +25,8 @@ use crate::dns::DNSError;
 use crate::metrics;
 use crate::metrics::MetricsType;
 
+use chrono::Utc;
+
 pub fn process(faythe_config: FaytheConfig, rx: Receiver<CertSpec>) {
 
     let mut queue: VecDeque<IssueOrder> = VecDeque::new();
@@ -82,7 +84,7 @@ fn check_queue(queue: &mut VecDeque<IssueOrder>) -> Result<(), IssuerError> {
                     IssuerError::DNS(dns::DNSError::WrongAnswer(domain)) => {
                         log::data("Wrong DNS answer", &domain);
                         // Retry for two hours. Propagation on gratisdns is pretty slow.
-                        if time::now_utc() < order.challenge_time + time::Duration::minutes(120) {
+                        if Utc::now() < order.challenge_time + chrono::Duration::minutes(120) {
                             queue.push_back(order);
                         } else {
                             log::data("giving up validating dns challenge for spec", &order.spec);
@@ -169,7 +171,7 @@ fn setup_challenge(config: &FaytheConfig, spec: &CertSpec) -> Result<IssueOrder,
         spec: spec.clone(),
         authorizations,
         inner: ord_new,
-        challenge_time: time::now_utc(),
+        challenge_time: Utc::now(),
         auth_dns_servers,
         val_dns_servers,
     })
@@ -179,7 +181,7 @@ struct IssueOrder {
     spec: CertSpec,
     inner: NewOrder<MemoryPersist>,
     authorizations: Vec<Auth<MemoryPersist>>,
-    challenge_time: time::Tm,
+    challenge_time: chrono::DateTime<Utc>,
     auth_dns_servers: HashSet<String>,
     val_dns_servers: HashSet<String>,
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,5 +1,3 @@
-extern crate time;
-
 use std::thread;
 use std::time::Duration;
 
@@ -23,6 +21,8 @@ use std::prelude::v1::Vec;
 
 use crate::metrics;
 use crate::metrics::MetricsType;
+
+use chrono::Utc;
 
 pub fn monitor_k8s(config: ConfigContainer, tx: Sender<CertSpec>) {
     log::info("k8s monitoring-started");
@@ -131,7 +131,6 @@ mod tests {
     use crate::mpsc;
     use crate::mpsc::{Receiver, Sender};
     use std::collections::HashSet;
-    use std::ops::Add;
 
     fn create_channel() -> (Sender<CertSpec>, Receiver<CertSpec>) {
         mpsc::channel()
@@ -141,7 +140,7 @@ mod tests {
         [Ingress {
             name: "test".to_string(),
             namespace: "test".to_string(),
-            touched: time::empty_tm(),
+            touched: chrono::DateTime::<Utc>::MIN_UTC,
             hosts: [host.clone()].to_vec(),
         }]
         .to_vec()
@@ -156,8 +155,8 @@ mod tests {
             cert: Cert {
                 cn: host.clone(),
                 sans,
-                valid_from: time::now_utc(),
-                valid_to: time::now_utc().add(time::Duration::days(valid_days)),
+                valid_from: Utc::now(),
+                valid_to: Utc::now() + chrono::Duration::days(valid_days),
             },
             key: vec![],
         }


### PR DESCRIPTION
Removes the old time dependency and switches all use to the more modern chrono crate. Tests pass but would love a proper review from someone familiar with the codebase. :)

I'm a bit concerned about the previous use of `time::empty_tm()`, as the documentation is a bit lacking, but I'm assuming that since it's mostly used for setting issuers' `touched`, it's used to represent the earliest possible time, so I've replaced it with `chrono::DateTime::MIN_UTC`.

Closes #9