### PR TITLE
fix(flake): remove warning from unused override of flake-utils by crane input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
     utils.url = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
     crane.inputs.nixpkgs.follows = "nixpkgs";
-    crane.inputs.flake-utils.follows = "utils";
   };
 
   outputs = { self, crane, nixpkgs, utils }:


### PR DESCRIPTION
Signed-off-by: Christina Sørensen <christina@cafkafk.com>
