### PR TITLE
build(direnv): add `.envrc` for automatic `nix develop` via `direnv`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if has nix; then
+  use flake .
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /target
 **/*.rs.bk
 result*
+
+.direnv


### PR DESCRIPTION
Signed-off-by: Christina Sørensen <christina@cafkafk.com>