### PR TITLE
cargo: add missing feature "blocking", since webhook challenges uses blocking reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -565,6 +566,7 @@ checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1440,6 +1442,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ vaultrs-login = "0"
 url = "2"
 chrono = "0"
 num-traits = "0"
-reqwest = { version = "0", features = ["json"] }
+reqwest = { version = "0", features = ["blocking", "json"] }
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
tldr, 5ba6dc8 upgraded reqwest from 0.11 -> 0.12. Reqwest fixed optional dependencies internally to make deps _actually_ optional, which then uncovered the mistake here of the missing feature-flag.

see: https://github.com/seanmonstar/reqwest/releases/tag/v0.12.0

For some reason there were no checks run on #87 ? A normal flake check would have revealed this. :shrug: 

**edit: yeah, it means main doesn't build atm.**