### PR TITLE
faster CI, that runs on main (meaning we can enforce branches are up to date)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
-      with:
-        nix_path: nixpkgs=channel:nixos-24.05
-    - run: nix --experimental-features "nix-command flakes" flake check
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix --experimental-features "nix-command flakes" flake check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,4 +16,4 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix --experimental-features "nix-command flakes" flake check -L
+      - run: nix flake check -L

--- a/.github/workflows/cheks.yml
+++ b/.github/workflows/cheks.yml
@@ -1,5 +1,11 @@
 name: "Checks"
-on: [ "pull_request" ]
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/cheks.yml
+++ b/.github/workflows/cheks.yml
@@ -16,4 +16,4 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix --experimental-features "nix-command flakes" flake check
+      - run: nix --experimental-features "nix-command flakes" flake check -L

--- a/.github/workflows/cheks.yml
+++ b/.github/workflows/cheks.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: "Checks"
 on: [ "pull_request" ]
 jobs:
   tests:


### PR DESCRIPTION
This adds faster CI leveraging the GitHub actions cache via DetSys magic nix cache. It also improves conditions for running CI checks, making checks run on the main branch allowing us to setup branch protection rules to ensure PRs are up to date before being merge.

This will prevent situations like #87 from happening where CI checks have been added but the base branch is so old that it does not contain them yet.