### PR TITLE
pin crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,28 +4,28 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+acme-lib = { git = 'https://github.com/DBCDK/acme-lib', branch = 'dbc-fork' }
+async-trait = { version = "0" }
+base64 = "0"
+chrono = "0"
 clap = { version = "=4.4", features = ["cargo"] } # We force 4.4 so we don't have to use rustc 1.74
+dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "main" }
+env_logger = "0"
+lazy_static = "1"
+num-traits = "0"
+openssl = "0"
+prometheus_exporter_base = { version = "=1.4.0", features = ["hyper_server"] }
+regex = "1"
+reqwest = { version = "0", features = ["blocking", "json"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-openssl = "0"
-base64 = "0"
-acme-lib = { git = 'https://github.com/DBCDK/acme-lib', branch = 'dbc-fork' }
-regex = "1"
-lazy_static = "1"
-walkdir = "2"
-trust-dns-resolver = "0"
-env_logger = "0"
-prometheus_exporter_base = { version = "=1.4.0", features = ["hyper_server"] }
 tokio = { version = "1", features = [ "full" ] }
-async-trait = { version = "0" }
-dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "main" }
+trust-dns-resolver = "0"
+url = "2"
 vaultrs = "0"
 vaultrs-login = "0"
-url = "2"
-chrono = "0"
-num-traits = "0"
-reqwest = { version = "0", features = ["blocking", "json"] }
+walkdir = "2"
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,26 +5,26 @@ edition = "2018"
 
 [dependencies]
 acme-lib = { git = 'https://github.com/DBCDK/acme-lib', branch = 'dbc-fork' }
-async-trait = { version = "0" }
-base64 = "0"
-chrono = "0"
+async-trait = { version = "0.1" }
+base64 = "0.22"
+chrono = "0.4"
 clap = { version = "=4.4", features = ["cargo"] } # We force 4.4 so we don't have to use rustc 1.74
 dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "main" }
-env_logger = "0"
+env_logger = "0.11"
 lazy_static = "1"
-num-traits = "0"
-openssl = "0"
+num-traits = "0.2"
+openssl = "0.10"
 prometheus_exporter_base = { version = "=1.4.0", features = ["hyper_server"] }
 regex = "1"
-reqwest = { version = "0", features = ["blocking", "json"] }
+reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 tokio = { version = "1", features = [ "full" ] }
-trust-dns-resolver = "0"
+trust-dns-resolver = "0.23"
 url = "2"
-vaultrs = "0"
-vaultrs-login = "0"
+vaultrs = "0.7"
+vaultrs-login = "0.2"
 walkdir = "2"
 
 [profile.release]


### PR DESCRIPTION
~stacked on #91~ no longer stacked, since there seems to be a file descriptor issue

Currently, several versions are locked on 0. Because of how semver
works, this means that of these dependencies are allow to freely be
upgraded with breaking changes. Essentially, it's equivalent to setting
*, only as long as it doesn't go to a "one dot" release.

Most of the cargo ecosystem is pre one dot, and will be so forever, so
this is extremely brittle.

faythe v0.1.0 (/home/ces/org/src/dbc/faythe/.worktree/pin-crates)
├── acme-lib v0.8.1 (https://github.com/DBCDK/acme-lib?branch=dbc-fork#6ae27e4e)
├── async-trait v0.1.83 (proc-macro)
├── base64 v0.22.1
├── chrono v0.4.38
├── clap v4.4.18
├── dbc-rust-modules v0.1.0 (https://github.com/dbcdk/rust-modules?branch=main#ab38efd1)
├── env_logger v0.11.5
├── lazy_static v1.5.0
├── num-traits v0.2.19
│   [build-dependencies]
├── openssl v0.10.66
├── prometheus_exporter_base v1.4.0
├── regex v1.11.0
├── reqwest v0.12.7
├── serde v1.0.210
├── serde_derive v1.0.210 (proc-macro)
├── serde_json v1.0.128
├── tokio v1.40.0
├── trust-dns-resolver v0.23.2
├── url v2.5.2
├── vaultrs v0.7.2
├── vaultrs-login v0.2.1
└── walkdir v2.5.0

Signed-off-by: Christina Sørensen <christina@cafkafk.com>
