### PR TITLE
Fail the build on rustc warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,11 @@
       # upstream ideally) so this interface might be brittle, but avoids
       # accidentally passing a detached nixpkgs from its flake (or its follows)
       # on to consumers.
-      craneLib = crane.mkLib final;
+      craneLib = (crane.mkLib final).overrideScope (_: scopePrev: {
+        mkCargoDerivation = args: scopePrev.mkCargoDerivation ({
+          RUSTFLAGS = "-D warnings";
+        } // args);
+      });
     };
   in {
     packages.${system}.${pname} = pkgs.${pname};

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -240,7 +240,10 @@ impl std::convert::From<common::SpecError> for IssuerError {
 #[derive(Debug)]
 enum ResolverError<'l> {
     SystemResolveConf,
-    NoIpsForResolversFound(&'l String),
+    NoIpsForResolversFound(
+        #[allow(dead_code)]
+        &'l String
+    ),
     Other
 }
 


### PR DESCRIPTION
Prevents many preventable mistakes and ensures proper code cleanup after removed features etc.