### PR TITLE
build(deps): pin dependencies according to cargo semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,23 +8,23 @@ clap = { version = "=4.4", features = ["cargo"] } # We force 4.4 so we don't hav
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-openssl = "0"
-base64 = "0"
+openssl = "0.10"
+base64 = "0.22"
 acme-lib = { git = 'https://github.com/DBCDK/acme-lib', branch = 'dbc-fork' }
 regex = "1"
 lazy_static = "1"
 walkdir = "2"
 trust-dns-resolver = { version = "0", features = ["tokio-runtime"] }
-env_logger = "0"
+env_logger = "0.11"
 prometheus_exporter_base = { version = "=1.4.0", features = ["hyper_server"] }
 tokio = { version = "1", features = [ "full" ] }
-async-trait = { version = "0" }
+async-trait = { version = "0.1" }
 dbc-rust-modules = { git = "https://github.com/dbcdk/rust-modules", branch = "main" }
-vaultrs = "0"
-vaultrs-login = "0"
+vaultrs = "0.7"
+vaultrs-login = "0.2"
 url = "2"
-chrono = "0"
-num-traits = "0"
+chrono = "0.4"
+num-traits = "0.2"
 reqwest = { version = "0", features = ["blocking", "json"] }
 
 [profile.release]


### PR DESCRIPTION
> This guide uses the terms “major” and “minor” assuming this relates to
> a “1.0.0” release or later. Initial development releases starting with
> “0.y.z” can treat changes in “y” as a major release, and “z” as a minor
> release. “0.0.z” releases are always major changes. This is because
> Cargo uses the convention that only changes in the left-most non-zero
> component are considered incompatible.

https://doc.rust-lang.org/cargo/reference/semver.html

Signed-off-by: Christina Sørensen <ces@fem.gg>
