### PR TITLE
fix(renovate): config issues + refactor CI to be less tedious

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,19 @@ jobs:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v27
     - run: nix shell github:nixos/nixpkgs#renovate --command renovate-config-validator
-  tests:
+  clippy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v27
       with:
-        nix_path: nixpkgs=channel:nixos-24.05
-    - run: nix --experimental-features "nix-command flakes" flake check
+        nix_path: nixpkgs=channel:nixos-24.11
+    - run: nix build ./#checks.x86_64-linux.clippy
+  sample-configs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-24.11
+    - run: nix build ./#checks.x86_64-linux.sample-configs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: "Build"
 on: [ "pull_request" ]
 jobs:
+  validate-renovate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+    - run: nix shell github:nixos/nixpkgs#renovate --command renovate-config-validator
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,10 @@
         pkg-config
         rustc
         zlib.dev
-        dnsutils # runtime
+        # runtime
+        dnsutils
+        # needed to validdate renovate config
+        renovate
       ];
     };
   };

--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,10 @@
       "groupName": "Minor/Patch",
       "matchUpdateTypes":[
         "minor",
-        "patch",
+        "patch"
       ],
       "automerge":true
-    }
+    },
     {
       "groupName": "Pin/Digest/PinDigest/LockFileMaintenance",
       "matchUpdateTypes":[

--- a/vault-test.yml
+++ b/vault-test.yml
@@ -1,0 +1,16 @@
+name: "vault-test"
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+      - 'renovate.json'
+jobs:
+  vault-test:
+    runs-on: ubuntu-latest
+    if: "! ( ( contains(github.event.pull_request.changed_files, '.github/workflows/*') || contains(github.event.pull_request.changed_files, 'renovate.json') ) && length(github.event.pull_request.changed_files) == length(filter(github.event.pull_request.changed_files, x => x == '.github/workflows/*' || x == 'renovate.json' )) )"
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-24.11
+    - run: nix build ./#checks.x86_64-linux.vault


### PR DESCRIPTION
This PR:
- fixes the renovate json errors #113
- separates the flake checks into separate jobs #107
- makes the vault check ignore workflow and renovate changes #112
- adds a CI check for the renovate config being sound